### PR TITLE
Remove modular-adal-angular

### DIFF
--- a/app/adal/adal-request.js
+++ b/app/adal/adal-request.js
@@ -1,5 +1,5 @@
 var q = require('q');
-var AuthenticationContext = require('expose?AuthenticationContext!../../node_modules/modular-adal-angular/lib/adal.js');
+var AuthenticationContext = require('expose?AuthenticationContext!adal-angular');
 var adalConfig = require('./adal-config');
 
 var _adal = new AuthenticationContext(adalConfig);

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "adal-angular": "^1.0.12",
     "babel-preset-react": "^6.5.0",
     "expose-loader": "^0.7.1",
-    "modular-adal-angular": "^0.3.0",
     "office-ui-fabric": "^2.2.0",
     "q": "^1.4.1",
     "react": "^0.14.7",


### PR DESCRIPTION
This removes the out of date package, `modular-adal-angular`. The official `adal-angular` now exports the `AuthenticationContext` object by default, and can be used in it's place for applications without Angular.

Expose loader is still required to set `window.AuthenticationContext`, to allow the spawned iframes to have access to the object.